### PR TITLE
Changes to RK to work-around issues with stable RK

### DIFF
--- a/ResearchKit/ActiveTasks/ORKTappingContentView.h
+++ b/ResearchKit/ActiveTasks/ORKTappingContentView.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setTapCount:(NSUInteger)tapCount;
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated;
 
+@property (nonatomic, assign) BOOL hasSkipButton;
+
 @property (nonatomic, strong, readonly) ORKRoundTappingButton *tapButton1;
 
 @property (nonatomic, strong, readonly) ORKRoundTappingButton *tapButton2;

--- a/ResearchKit/ActiveTasks/ORKTappingContentView.m
+++ b/ResearchKit/ActiveTasks/ORKTappingContentView.m
@@ -177,7 +177,7 @@
     const CGFloat AssumedHeaderBaselineToStepViewTop = ORKGetMetricForScreenType(ORKScreenMetricLearnMoreBaselineToStepViewTop, screenType);
     
     static const CGFloat CaptionBaselineToTapCountBaseline = 56;
-    static const CGFloat TapButtonBottomToBottom = 36;
+    CGFloat tapButtonBottomToBottom = self.hasSkipButton ? 0 : 36;
     
     // On the iPhone, _progressView is positioned outside the bounds of this view, to be in-between the header and this view.
     // On the iPad, we want to stretch this out a bit so it feels less compressed.
@@ -219,7 +219,7 @@
                                                         relatedBy:NSLayoutRelationEqual
                                                            toItem:_buttonContainer
                                                         attribute:NSLayoutAttributeBottom
-                                                       multiplier:1 constant:TapButtonBottomToBottom]];
+                                                       multiplier:1 constant:tapButtonBottomToBottom]];
     
     [constraints addObjectsFromArray:
      [NSLayoutConstraint constraintsWithVisualFormat:@"V:[_tapCountLabel]-(>=10)-[_buttonContainer]"

--- a/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKTappingIntervalStepViewController.m
@@ -93,6 +93,7 @@
     _expired = NO;
     
     _tappingContentView = [[ORKTappingContentView alloc] init];
+    _tappingContentView.hasSkipButton = self.step.optional;
     self.activeStepView.activeCustomView = _tappingContentView;
     
     [_tappingContentView.tapButton1 addTarget:self action:@selector(buttonPressed:forEvent:) forControlEvents:UIControlEventTouchDown];

--- a/ResearchKit/Common/ORKStep.h
+++ b/ResearchKit/Common/ORKStep.h
@@ -83,6 +83,15 @@ ORK_CLASS_AVAILABLE
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
 
 /**
+ Returns a copy of this step initialized with the specified identifier.
+ 
+ @param identifier   The unique identifier of the step.
+ 
+ @return A new step.
+ */
+- (instancetype)copyWithIdentifier:(NSString *)identifier;
+
+/**
  A short string that uniquely identifies the step within the task.
  
  The identifier is reproduced in the results of a step. In fact, the only way to link a result

--- a/ResearchKit/Common/ORKStep.m
+++ b/ResearchKit/Common/ORKStep.m
@@ -55,6 +55,12 @@
     return [ORKStepViewController class];
 }
 
+- (instancetype)copyWithIdentifier:(NSString *)identifier {
+    ORKStep *step = [self copy];
+    step->_identifier = identifier;
+    return step;
+}
+
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKStep *step = [[[self class] allocWithZone:zone] initWithIdentifier:[_identifier copy]];
     step.title = _title;


### PR DESCRIPTION
In order to implement bilateral tapping activity, it is necessary to work-around the private membership of ORKTappingIntervalStep. Additionally, there was a layout bug that moved the "skip" button offscreen and there was no means of instantiating a copy of an existing step with a new identifier. These changes are added with this pull request.
