### PR TITLE
Add method for creating an completion step.

### DIFF
--- a/ResearchKit/Common/ORKInstructionStep.h
+++ b/ResearchKit/Common/ORKInstructionStep.h
@@ -64,4 +64,10 @@ ORK_CLASS_AVAILABLE
 
 @end
 
+@interface ORKInstructionStep (ORKPredefinedSteps)
+
++ (ORKInstructionStep*)completionStep;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/Common/ORKInstructionStep.m
+++ b/ResearchKit/Common/ORKInstructionStep.m
@@ -33,6 +33,8 @@
 #import "ORKHelpers.h"
 #import "ORKStep_Private.h"
 #import "ORKInstructionStepViewController.h"
+#import "ORKCompletionStep.h"
+#import "ORKDefines_Private.h"
 
 
 @implementation ORKInstructionStep
@@ -79,3 +81,18 @@
 }
 
 @end
+
+static NSString * const ORKConclusionStepIdentifier = @"conclusion";
+
+@implementation ORKInstructionStep (ORKPredefinedSteps)
+
++ (ORKInstructionStep *)completionStep {
+    ORKCompletionStep *step = [[ORKCompletionStep alloc] initWithIdentifier:ORKConclusionStepIdentifier];
+    step.title = ORKLocalizedString(@"TASK_COMPLETE_TITLE", nil);
+    step.text = ORKLocalizedString(@"TASK_COMPLETE_TEXT", nil);
+    step.shouldTintImages = YES;
+    return step;
+}
+
+@end
+


### PR DESCRIPTION
The ORKCompletionStep is not exposed publicly. Being able to use this step for activities and surveys that are not a part of ResearchKit will allow for a consistent UX.
