### PR TITLE
bug/BRIDGE-1054

### DIFF
--- a/ResearchKit/Common/ORKResult.m
+++ b/ResearchKit/Common/ORKResult.m
@@ -1730,6 +1730,12 @@ const NSUInteger NumberOfPaddingSpacesForIndentationLevel = 4;
 }
 
 - (id)answer {
+    // ORKDateQuestionResult can be of type ORKQuestionTypeDate or ORKQuestionTypeDateAndTime
+    // If our type is ORKQuestionTypeDate, we will output only the Date and leave out the time
+    // per the server guide
+    if (self.questionType == ORKQuestionTypeDate) {
+        return [ORKResultDateFormatter() stringFromDate:self.dateAnswer];
+    }
     return self.dateAnswer;
 }
 


### PR DESCRIPTION
Format date to discard time portion on ORKDateQuestionResult.

To test this, make a user with "+test" suffix in mPower, and do the survey "Time Test (only appears for test users, do not be alarmed)" and look at the log output of what it sends to the survey.  Before, it would send full ISO8601 string, now it only sends "YYYY-MM-DD" for date.
