### PR TITLE
bug/name_entry

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -1270,6 +1270,13 @@ ORK_CLASS_AVAILABLE
 @property(nonatomic,getter=isSecureTextEntry) BOOL secureTextEntry;
 
 /**
+ Identifies whether the text object should be allowed to be blank strings, aka all whitespace, like "   ".
+ 
+ By default, the value of this property is NO.
+ */
+@property (nonatomic) BOOL disallowBlankString;
+
+/**
  Returns an answer format that can be used for confirming a text entry.
  
  This answer format produces an `ORKBooleanQuestionResult` object.

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1943,6 +1943,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     fmt->_keyboardType = _keyboardType;
     fmt->_multipleLines = _multipleLines;
     fmt->_secureTextEntry = _secureTextEntry;
+    fmt->_disallowBlankString = _disallowBlankString;
     return fmt;
 }
 
@@ -1958,6 +1959,12 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     BOOL isValid = YES;
     if (text && text.length > 0) {
         isValid = ([self isTextLengthValidWithString:text] && [self isTextRegexValidWithString:text]);
+    }
+    // Disallow any string that is blank, like "     ".
+    if (self.disallowBlankString && text.length > 0) {
+        if([text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]].length == 0) {
+            isValid = NO;
+        }
     }
     return isValid;
 }

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1513,20 +1513,6 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return ORKQuestionTypeScale;
 }
 
-- (NSUInteger)hash {
-    return  [super hash]                        ^
-            [_validationRegex hash]             ^
-            [_invalidMessage hash]              ^
-            [@(_maximumLength) hash]            ^
-            [@(_autocapitalizationType) hash]   ^
-            [@(_autocorrectionType) hash]       ^
-            [@(_spellCheckingType) hash]        ^
-            [@(_keyboardType) hash]             ^
-            [@(_multipleLines) hash]            ^
-            [@(_multipleLines) hash]            ^
-            [@(_disallowEmptyString) hash];
-}
-
 @end
 
 
@@ -2088,6 +2074,20 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
              self.multipleLines == castObject.multipleLines) &&
              self.secureTextEntry == castObject.secureTextEntry) &&
              self.disallowBlankString == castObject.disallowBlankString;
+}
+
+- (NSUInteger)hash {
+    return  [super hash]                        ^
+            [_validationRegex hash]             ^
+            [_invalidMessage hash]              ^
+            [@(_maximumLength) hash]            ^
+            [@(_autocapitalizationType) hash]   ^
+            [@(_autocorrectionType) hash]       ^
+            [@(_spellCheckingType) hash]        ^
+            [@(_keyboardType) hash]             ^
+            [@(_multipleLines) hash]            ^
+            [@(_secureTextEntry) hash]          ^
+            [@(_disallowBlankString) hash];
 }
 
 @end

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1513,6 +1513,20 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     return ORKQuestionTypeScale;
 }
 
+- (NSUInteger)hash {
+    return  [super hash]                        ^
+            [_validationRegex hash]             ^
+            [_invalidMessage hash]              ^
+            [@(_maximumLength) hash]            ^
+            [@(_autocapitalizationType) hash]   ^
+            [@(_autocorrectionType) hash]       ^
+            [@(_spellCheckingType) hash]        ^
+            [@(_keyboardType) hash]             ^
+            [@(_multipleLines) hash]            ^
+            [@(_multipleLines) hash]            ^
+            [@(_disallowEmptyString) hash];
+}
+
 @end
 
 

--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -2016,6 +2016,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     fmt->_keyboardType = _keyboardType;
     fmt->_multipleLines = _multipleLines;
     fmt->_secureTextEntry = _secureTextEntry;
+    fmt->_disallowBlankString = _disallowBlankString;
     
     return fmt;
 }
@@ -2035,6 +2036,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         ORK_DECODE_ENUM(aDecoder, keyboardType);
         ORK_DECODE_BOOL(aDecoder, multipleLines);
         ORK_DECODE_BOOL(aDecoder, secureTextEntry);
+        ORK_DECODE_BOOL(aDecoder, disallowBlankString);
     }
     return self;
 }
@@ -2050,6 +2052,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
     ORK_ENCODE_ENUM(aCoder, keyboardType);
     ORK_ENCODE_BOOL(aCoder, multipleLines);
     ORK_ENCODE_BOOL(aCoder, secureTextEntry);
+    ORK_ENCODE_BOOL(aCoder, disallowBlankString);
 }
 
 + (BOOL)supportsSecureCoding {
@@ -2069,7 +2072,8 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
              self.spellCheckingType == castObject.spellCheckingType &&
              self.keyboardType == castObject.keyboardType &&
              self.multipleLines == castObject.multipleLines) &&
-             self.secureTextEntry == castObject.secureTextEntry);
+             self.secureTextEntry == castObject.secureTextEntry) &&
+             self.disallowBlankString == castObject.disallowBlankString;
 }
 
 @end

--- a/ResearchKit/Consent/ORKConsentReviewStepViewController.m
+++ b/ResearchKit/Consent/ORKConsentReviewStepViewController.m
@@ -177,6 +177,8 @@ static NSString *const _FamilyNameIdentifier = @"family";
         nameAnswerFormat.autocapitalizationType = UITextAutocapitalizationTypeWords;
         nameAnswerFormat.autocorrectionType = UITextAutocorrectionTypeNo;
         nameAnswerFormat.spellCheckingType = UITextSpellCheckingTypeNo;
+        nameAnswerFormat.disallowBlankString = YES;
+
         ORKFormItem *givenNameFormItem = [[ORKFormItem alloc] initWithIdentifier:_GivenNameIdentifier
                                                                   text:ORKLocalizedString(@"CONSENT_NAME_GIVEN", nil)
                                                           answerFormat:nameAnswerFormat];


### PR DESCRIPTION
We got this request for FPHS, but I figured it would be useful for all the apps, since a blank first or last name is undesired across the board.

To get the functionality, I added a property for invalidating blank strings in ork answer formats.  Enabled it for name entry in consent only.  Defaults to NO.
