### PR TITLE
Fix audio step duplicate file creation bug

### DIFF
--- a/ResearchKit/ActiveTasks/ORKAudioStep.m
+++ b/ResearchKit/ActiveTasks/ORKAudioStep.m
@@ -48,6 +48,7 @@
     self = [super initWithIdentifier:identifier];
     if (self) {
         self.shouldShowDefaultTimer = NO;
+        self.shouldStartTimerAutomatically = YES;
     }
     return self;
 }

--- a/ResearchKit/ActiveTasks/ORKAudioStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKAudioStepViewController.m
@@ -91,11 +91,6 @@
     self.activeStepView.activeCustomView = _audioContentView;
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];
-    [self start];
-}
-
 - (void)audioRecorderDidChange {
     _audioRecorder.audioRecorder.meteringEnabled = YES;
     [self setAvAudioRecorder:_audioRecorder.audioRecorder];


### PR DESCRIPTION
Start was getting called in viewDidAppear:, creating an audio file, and meanwhile the superclass viewDidAppear: had dispatched a block to main that then saw the recorder was started and called resume, creating another audio file, only one of which was included in the results, leaving the other which the caller didn't know about and wasn't aware needed to be deleted, using up storage space over time. The fix is to use the shouldStartTimerAutomatically flag to let the superclass viewDidAppear: start the recorder, rather than override that method in the audio step view controller to start it explicitly.