### PR TITLE
Allow interhitance of navigation rules outside ResearchKit

### DIFF
--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.h
@@ -38,6 +38,15 @@ NS_ASSUME_NONNULL_BEGIN
 ORK_CLASS_AVAILABLE
 @interface ORKAudioLevelNavigationRule : ORKStepNavigationRule
 
+/*
+ The `init` and `new` methods are unavailable.
+ 
+ `ORKStepNavigationRule` classes should be initialized with custom designated initializers on each
+ subclass.
+ */
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  Returns an initialized direct-step navigation rule using the specified destination step identifier.
  

--- a/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
+++ b/ResearchKit/ActiveTasks/ORKAudioLevelNavigationRule.m
@@ -58,6 +58,14 @@ Float32 const VolumeClamp = 60.0;
 
 @implementation ORKAudioLevelNavigationRule
 
++ (instancetype)new {
+    ORKThrowMethodUnavailableException();
+}
+
+- (instancetype)init {
+    ORKThrowMethodUnavailableException();
+}
+
 - (instancetype)initWithAudioLevelStepIdentifier:(NSString *)audioLevelStepIdentifier
                        destinationStepIdentifier:(NSString *)destinationStepIdentifier
                                recordingSettings:(NSDictionary *)recordingSettings
@@ -65,7 +73,7 @@ Float32 const VolumeClamp = 60.0;
     ORKThrowInvalidArgumentExceptionIfNil(audioLevelStepIdentifier);
     ORKThrowInvalidArgumentExceptionIfNil(destinationStepIdentifier);
     ORKThrowInvalidArgumentExceptionIfNil(recordingSettings);
-    self = [super init_ork];
+    self = [super init];
     if (self) {
         _audioLevelStepIdentifier = [audioLevelStepIdentifier copy];
         _destinationStepIdentifier = [destinationStepIdentifier copy];

--- a/ResearchKit/Common/ORKStepNavigationRule.h
+++ b/ResearchKit/Common/ORKStepNavigationRule.h
@@ -63,14 +63,8 @@ ORK_EXTERN NSString *const ORKNullStepIdentifier ORK_AVAILABLE_DECL;
 ORK_CLASS_AVAILABLE
 @interface ORKStepNavigationRule : NSObject <NSCopying, NSSecureCoding>
 
-/*
- The `init` and `new` methods are unavailable.
- 
- `ORKStepNavigationRule` classes should be initialized with custom designated initializers on each
- subclass.
- */
-+ (instancetype)new NS_UNAVAILABLE;
-- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
 
 /**
  Returns the target step identifier.
@@ -106,6 +100,15 @@ ORK_CLASS_AVAILABLE
  */
 ORK_CLASS_AVAILABLE
 @interface ORKPredicateStepNavigationRule : ORKStepNavigationRule
+
+/*
+ The `init` and `new` methods are unavailable.
+ 
+ `ORKStepNavigationRule` classes should be initialized with custom designated initializers on each
+ subclass.
+ */
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  Returns an initialized predicate step navigation rule using the specified result predicates,
@@ -203,6 +206,15 @@ ORK_CLASS_AVAILABLE
 ORK_CLASS_AVAILABLE
 @interface ORKDirectStepNavigationRule : ORKStepNavigationRule
 
+/*
+ The `init` and `new` methods are unavailable.
+ 
+ `ORKStepNavigationRule` classes should be initialized with custom designated initializers on each
+ subclass.
+ */
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  Returns an initialized direct-step navigation rule using the specified destination step identifier.
  
@@ -250,14 +262,8 @@ ORK_CLASS_AVAILABLE
 ORK_CLASS_AVAILABLE
 @interface ORKSkipStepNavigationRule : NSObject <NSCopying, NSSecureCoding>
 
-/*
- The `init` and `new` methods are unavailable.
- 
- `ORKStepNavigationRule` classes should be initialized with custom designated initializers on each
- subclass.
- */
-+ (instancetype)new NS_UNAVAILABLE;
-- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
 
 /**
  Returns whether the targeted step should skip.
@@ -276,6 +282,15 @@ ORK_CLASS_AVAILABLE
 
 ORK_CLASS_AVAILABLE
 @interface ORKPredicateSkipStepNavigationRule : ORKSkipStepNavigationRule
+
+/*
+ The `init` and `new` methods are unavailable.
+ 
+ `ORKStepNavigationRule` classes should be initialized with custom designated initializers on each
+ subclass.
+ */
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  Returns an initialized predicate skip step navigation rule using the specified result predicate.

--- a/ResearchKit/Common/ORKStepNavigationRule.m
+++ b/ResearchKit/Common/ORKStepNavigationRule.m
@@ -43,15 +43,10 @@ NSString *const ORKNullStepIdentifier = @"org.researchkit.step.null";
 
 @implementation ORKStepNavigationRule
 
-+ (instancetype)new {
-    ORKThrowMethodUnavailableException();
-}
-
 - (instancetype)init {
-    ORKThrowMethodUnavailableException();
-}
-
-- (instancetype)init_ork {
+    if ([self isMemberOfClass:[ORKStepNavigationRule class]]) {
+        ORKThrowMethodUnavailableException();
+    }
     return [super init];
 }
 
@@ -75,7 +70,7 @@ NSString *const ORKNullStepIdentifier = @"org.researchkit.step.null";
 #pragma mark NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    __typeof(self) rule = [[[self class] allocWithZone:zone] init_ork];
+    __typeof(self) rule = [[[self class] allocWithZone:zone] init];
     return rule;
 }
 
@@ -100,6 +95,14 @@ NSString *const ORKNullStepIdentifier = @"org.researchkit.step.null";
 
 @implementation ORKPredicateStepNavigationRule
 
++ (instancetype)new {
+    ORKThrowMethodUnavailableException();
+}
+
+- (instancetype)init {
+    ORKThrowMethodUnavailableException();
+}
+
 // Internal init without array validation, for serialization support
 - (instancetype)initWithResultPredicates:(NSArray<NSPredicate *> *)resultPredicates
               destinationStepIdentifiers:(NSArray<NSString *> *)destinationStepIdentifiers
@@ -123,7 +126,7 @@ NSString *const ORKNullStepIdentifier = @"org.researchkit.step.null";
             @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"defaultStepIdentifier must be of a NSString class kind or nil" userInfo:nil];
         }
     }
-    self = [super init_ork];
+    self = [super init];
     if (self) {
         _resultPredicates = [resultPredicates copy];
         _destinationStepIdentifiers = [destinationStepIdentifiers copy];
@@ -266,9 +269,17 @@ static void ORKValidateIdentifiersUnique(NSArray *results, NSString *exceptionRe
 
 @implementation ORKDirectStepNavigationRule
 
++ (instancetype)new {
+    ORKThrowMethodUnavailableException();
+}
+
+- (instancetype)init {
+    ORKThrowMethodUnavailableException();
+}
+
 - (instancetype)initWithDestinationStepIdentifier:(NSString *)destinationStepIdentifier {
     ORKThrowInvalidArgumentExceptionIfNil(destinationStepIdentifier);
-    self = [super init_ork];
+    self = [super init];
     if (self) {
         _destinationStepIdentifier = destinationStepIdentifier;
     }
@@ -322,15 +333,10 @@ static void ORKValidateIdentifiersUnique(NSArray *results, NSString *exceptionRe
 
 @implementation ORKSkipStepNavigationRule
 
-+ (instancetype)new {
-    ORKThrowMethodUnavailableException();
-}
-
 - (instancetype)init {
-    ORKThrowMethodUnavailableException();
-}
-
-- (instancetype)init_ork {
+    if ([self isMemberOfClass:[ORKSkipStepNavigationRule class]]) {
+        ORKThrowMethodUnavailableException();
+    }
     return [super init];
 }
 
@@ -354,7 +360,7 @@ static void ORKValidateIdentifiersUnique(NSArray *results, NSString *exceptionRe
 #pragma mark NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    typeof(self) rule = [[[self class] allocWithZone:zone] init_ork];
+    typeof(self) rule = [[[self class] allocWithZone:zone] init];
     return rule;
 }
 
@@ -377,9 +383,17 @@ static void ORKValidateIdentifiersUnique(NSArray *results, NSString *exceptionRe
 
 @implementation ORKPredicateSkipStepNavigationRule
 
++ (instancetype)new {
+    ORKThrowMethodUnavailableException();
+}
+
+- (instancetype)init {
+    ORKThrowMethodUnavailableException();
+}
+
 - (instancetype)initWithResultPredicate:(NSPredicate *)resultPredicate {
     ORKThrowInvalidArgumentExceptionIfNil(resultPredicate);
-    self = [super init_ork];
+    self = [super init];
     if (self) {
         _resultPredicate = resultPredicate;
     }
@@ -456,6 +470,9 @@ static void ORKValidateIdentifiersUnique(NSArray *results, NSString *exceptionRe
 @implementation ORKStepModifier
 
 - (instancetype)init {
+    if ([self isMemberOfClass:[ORKStepModifier class]]) {
+        ORKThrowMethodUnavailableException();
+    }
     return [super init];
 }
 

--- a/ResearchKit/Common/ORKStepNavigationRule_Internal.h
+++ b/ResearchKit/Common/ORKStepNavigationRule_Internal.h
@@ -34,13 +34,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface ORKStepNavigationRule ()
-
-- (instancetype)init_ork;
-
-@end
-
-
 @interface ORKPredicateStepNavigationRule ()
 
 + (NSArray *)leafResultsFromTaskResult:(ORKTaskResult *)ORKTaskResult;

--- a/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
+++ b/Testing/ORKTest/ORKTestTests/ORKJSONSerializationTests.m
@@ -181,6 +181,7 @@
  */
 ORK_MAKE_TEST_INIT(ORKStepNavigationRule, ^{return [super init];});
 ORK_MAKE_TEST_INIT(ORKSkipStepNavigationRule, ^{return [super init];});
+ORK_MAKE_TEST_INIT(ORKStepModifier, ^{return [super init];});
 ORK_MAKE_TEST_INIT(ORKKeyValueStepModifier, ^{return [super init];});
 ORK_MAKE_TEST_INIT(ORKAnswerFormat, ^{return [super init];});
 ORK_MAKE_TEST_INIT(ORKLoginStep, ^{return [self initWithIdentifier:[NSUUID UUID].UUIDString title:@"title" text:@"text" loginViewControllerClass:NSClassFromString(@"ORKLoginStepViewController") ];});
@@ -750,6 +751,7 @@ ORK_MAKE_TEST_INIT(CLCircularRegion, (^{
     @try {
         if (([c isSubclassOfClass:[ORKStepNavigationRule class]]) ||
             ([c isSubclassOfClass:[ORKSkipStepNavigationRule class]]) ||
+            ([c isSubclassOfClass:[ORKStepModifier class]]) ||
             ([c isSubclassOfClass:[ORKStep class]]) ||
             (c == [ORKKeyValueStepModifier class]) ||
              ([c isSubclassOfClass:[ORKOrderedTask class]]) ||
@@ -773,7 +775,13 @@ ORK_MAKE_TEST_INIT(CLCircularRegion, (^{
 }
 
 - (void)testEquality {
-    NSArray *classesExcluded = @[]; // classes not intended to be serialized standalone
+    NSArray *classesExcluded = @[
+                                 [ORKStepNavigationRule class],     // abstract base class
+                                 [ORKSkipStepNavigationRule class],     // abstract base class
+                                 [ORKStepModifier class],     // abstract base class
+                                 ];
+    
+    
     // Each time ORKRegistrationStep returns a new date in its answer fromat, cannot be tested.
     NSMutableArray *stringsForClassesExcluded = [NSMutableArray arrayWithObjects:NSStringFromClass([ORKRegistrationStep class]), nil];
     for (Class c in classesExcluded) {


### PR DESCRIPTION
This will still throw an exception if the developer attempts to initialize an instance of the base class without inheriting it but allows developers to create navigation rules that inherit directly from the base class.

https://github.com/ResearchKit/ResearchKit/pull/901