### PR TITLE
Fix the loop for the case where the UITableViewDelegate and this protocol clash

### DIFF
--- a/ResearchKit/Common/ORKTableStep.h
+++ b/ResearchKit/Common/ORKTableStep.h
@@ -88,22 +88,24 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Optional override to return custom header title for section. The default returns `nil`.
  
- @param tableView       The table view for custom section header title
  @param section         The section for this custom header title
+ @param tableView       The table view for custom section header title
+ 
  @return                The custom header title for this section
  */
 @optional
-- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section;
+- (nullable NSString *)titleForHeaderInSection:(NSInteger)section tableView:(UITableView *)tableView;
 
 /**
  Optional override to return custom header view for section. The default returns `nil`.
  
- @param tableView       The table view for custom section header view
  @param section         The section for this custom header view
+ @param tableView       The table view for custom section header view
+ 
  @return                The custom header view for this section
  */
 @optional
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section;
+- (nullable UIView *)viewForHeaderInSection:(NSInteger)section tableView:(UITableView *)tableView;
 
 @end
 

--- a/ResearchKit/Common/ORKTableStepViewController.m
+++ b/ResearchKit/Common/ORKTableStepViewController.m
@@ -186,16 +186,16 @@ ORKDefineStringKey(ORKBasicCellReuseIdentifier);
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
-    if ([self.tableStep respondsToSelector:@selector(tableView:titleForHeaderInSection:)]) {
-        return [self.tableStep tableView:tableView titleForHeaderInSection:section];
+    if ([self.tableStep respondsToSelector:@selector(titleForHeaderInSection:tableView:)]) {
+        return [self.tableStep titleForHeaderInSection:section tableView:tableView];
     } else {
         return nil;
     }
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
-    if ([self.tableStep respondsToSelector:@selector(tableView:viewForHeaderInSection:)]) {
-        return [self.tableStep tableView:tableView viewForHeaderInSection:section];
+    if ([self.tableStep respondsToSelector:@selector(viewForHeaderInSection:tableView:)]) {
+        return [self.tableStep viewForHeaderInSection:section tableView:tableView];
     } else {
         return nil;
     }


### PR DESCRIPTION
It you point the `ORKTableStepSource` at the view controller then this will result in an infinite loop of wacky madness. Change the protocol to match the other methods in the protocol that provide a pointer to the table view as the last parameter.