### PR TITLE
Add CI to builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,15 @@ DerivedData
 
 .DS_Store
 *.pyc
+
+# fastlane specific
+fastlane/report.xml
+
+# deliver temporary files
+fastlane/Preview.html
+
+# snapshot generated screenshots
+fastlane/screenshots
+
+# scan temporary files
+fastlane/test_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: objective-c
+osx_image: xcode8.2
+before_install:
+  - brew update
+install:
+  - ./travis/install-fastlane.sh
+  - export PATH="$HOME/.fastlane/bin:$PATH"
+script:
+  - ./travis/run-tests.sh
+

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,7 @@
+app_identifier "org.researchkit.ResearchKit" # The bundle identifier of your app
+apple_id "apple.developer@sagebase.org" # Your Apple email address
+
+team_id "4B822CZK9N"  # Developer Portal Team ID
+
+# you can even provide different app identifiers, Apple IDs and team names per lane:
+# More information: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Appfile.md

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,70 @@
+# Customise this file, documentation can be found here:
+# https://github.com/fastlane/fastlane/tree/master/fastlane/docs
+# All available actions: https://docs.fastlane.tools/actions
+# can also be listed using the `fastlane actions` command
+
+# Change the syntax highlighting to Ruby
+# All lines starting with a # are ignored when running `fastlane`
+
+# If you want to automatically update fastlane if a new version is available:
+# update_fastlane
+
+# This is the minimum version number required.
+# Update this, if you use features of a newer version
+fastlane_version "2.17.1"
+
+default_platform :ios
+
+platform :ios do
+  before_all do
+    # ENV["SLACK_URL"] = "https://hooks.slack.com/services/..."
+    # ensure_git_status_clean 
+    
+  end
+
+  desc "Runs all the tests"
+  lane :test do |options|
+    if options[:scheme]
+      scan(scheme: options[:scheme])
+    else
+      scan
+    end
+  end
+
+  desc "Submit a new Beta Build to Apple TestFlight"
+  desc "This will also make sure the profile is up to date"
+  lane :beta do
+    # match(type: "appstore") # more information: https://codesigning.guide
+    gym(scheme: "ResearchKit") # Build your app - more options available
+    pilot
+
+    # sh "your_script.sh"
+    # You can also use other beta testing services here (run `fastlane actions`)
+  end
+
+  desc "Deploy a new version to the App Store"
+  lane :release do
+    # match(type: "appstore")
+    # snapshot
+    gym(scheme: "ResearchKit") # Build your app - more options available
+    deliver(force: true)
+    # frameit
+  end
+
+  # You can define as many lanes as you want
+
+  after_all do |lane|
+    # This block is called, only if the executed lane was successful
+
+    # slack(
+    #   message: "Successfully deployed new App Update."
+    # )
+  end
+
+  error do |lane, exception|
+    # slack(
+    #   message: exception.message,
+    #   success: false
+    # )
+  end
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,54 @@
+fastlane documentation
+================
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```
+xcode-select --install
+```
+
+## Choose your installation method:
+
+<table width="100%" >
+<tr>
+<th width="33%"><a href="http://brew.sh">Homebrew</a></td>
+<th width="33%">Installer Script</td>
+<th width="33%">Rubygems</td>
+</tr>
+<tr>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS</td>
+<td width="33%" align="center">macOS or Linux with Ruby 2.0.0 or above</td>
+</tr>
+<tr>
+<td width="33%"><code>brew cask install fastlane</code></td>
+<td width="33%"><a href="https://download.fastlane.tools/fastlane.zip">Download the zip file</a>. Then double click on the <code>install</code> script (or run it in a terminal window).</td>
+<td width="33%"><code>sudo gem install fastlane -NV</code></td>
+</tr>
+</table>
+# Available Actions
+## iOS
+### ios test
+```
+fastlane ios test
+```
+Runs all the tests
+### ios beta
+```
+fastlane ios beta
+```
+Submit a new Beta Build to Apple TestFlight
+
+This will also make sure the profile is up to date
+### ios release
+```
+fastlane ios release
+```
+Deploy a new version to the App Store
+
+----
+
+This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/travis/install-fastlane.sh
+++ b/travis/install-fastlane.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -ex
+brew cask install fastlane
+gem update fastlane

--- a/travis/run-tests.sh
+++ b/travis/run-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -ex
+# show available schemes
+xcodebuild -list -project ./ResearchKit.xcodeproj
+# run on pull request
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+  fastlane test scheme:"ResearchKit"
+  exit $?
+fi


### PR DESCRIPTION
Step one in breaking from ResearchKit seems to be pulling our changes into our master. I think that pointing at master is less confusing. We can still keep a branch that is tied to product releases (and tagged).

Add the following to facilitate CI builds:
* fastlane - command line tool to build xcode apps
* travis - configurations for Travis CI