### PR TITLE
Moving a few things to make them more accessible

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -82,22 +82,11 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKHeightAnswerFormat)
 
 @property (nonatomic, strong, nullable) HKUnit *healthKitUserUnit;
 
-- (BOOL)isAnswerValid:(id)answer;
-
 - (nullable NSString *)localizedInvalidValueStringWithAnswerString:(nullable NSString *)text;
 
 - (nonnull Class)questionResultClass;
 
-- (ORKQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(id)answer;
-
 - (nullable NSString *)stringForAnswer:(id)answer;
-
-@end
-
-
-@interface ORKNumericAnswerFormat ()
-
-- (nullable NSString *)sanitizedTextFieldText:(nullable NSString *)text decimalSeparator:(nullable NSString *)separator;
 
 @end
 

--- a/ResearchKit/Common/ORKAnswerFormat_Private.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Private.h
@@ -31,6 +31,7 @@
 
 #import <ResearchKit/ORKAnswerFormat.h>
 
+@class ORKQuestionResult;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -39,10 +40,17 @@ ORK_EXTERN id ORKNullAnswerValue() ORK_AVAILABLE_DECL;
 
 @interface ORKAnswerFormat ()
 
+- (BOOL)isAnswerValid:(id)answer;
 - (BOOL)isAnswerValidWithString:(nullable NSString *)text;
+- (ORKQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(id)answer;
 
 @end
 
+@interface ORKNumericAnswerFormat ()
+
+- (nullable NSString *)sanitizedTextFieldText:(nullable NSString *)text decimalSeparator:(nullable NSString *)separator;
+
+@end
 
 /**
  The `ORKConfirmTextAnswerFormat` class represents the answer format for questions that collect a text


### PR DESCRIPTION
Moving a few abstract methods from _Internal.h to _Private.h so our ORKStepViewController subclass can access them.