### PR TITLE
Add overridable method for navigating without animation

### DIFF
--- a/ResearchKit/Common/ORKStepViewController.h
+++ b/ResearchKit/Common/ORKStepViewController.h
@@ -379,6 +379,11 @@ ORK_CLASS_AVAILABLE
 - (void)skipForward;
 
 /**
+ Indicates whether or not the navigation should be animated. default = `YES`
+ */
+- (BOOL)shouldAnimateNavigation;
+
+/**
  A Boolean value indicating whether the view controller has been presented before.
  */
 @property (nonatomic, readonly) BOOL hasBeenPresented;

--- a/ResearchKit/Common/ORKStepViewController.m
+++ b/ResearchKit/Common/ORKStepViewController.m
@@ -382,6 +382,9 @@ static Class __customContinueButtonClass;
     [self goForward];
 }
 
+- (BOOL)shouldAnimateNavigation {
+    return YES;
+}
 
 - (ORKTaskViewController *)taskViewController {
     // look to parent view controller for a task view controller

--- a/ResearchKit/Common/ORKTaskViewController.m
+++ b/ResearchKit/Common/ORKTaskViewController.m
@@ -1270,7 +1270,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
         if (fromController.isBeingReviewed) {
             [_managedStepIdentifiers removeLastObject];
         }
-        [self showViewController:stepViewController goForward:YES animated:YES];
+        [self showViewController:stepViewController goForward:YES animated:[fromController shouldAnimateNavigation]];
     }
     
 }
@@ -1296,7 +1296,7 @@ static NSString *const _ChildNavigationControllerRestorationKey = @"childNavigat
             assert([itemId isEqualToString:_managedStepIdentifiers.lastObject]);
             [_managedStepIdentifiers removeLastObject];
             
-            [self showViewController:stepViewController goForward:NO animated:YES];
+            [self showViewController:stepViewController goForward:NO animated:[fromController shouldAnimateNavigation]];
         }
     }
 }


### PR DESCRIPTION
Because the survey loads asynchronously, there is a view controller that is displayed momentarily before showing the introduction screen. The animation is jarring so allow the step view controller to indicate that navigation should not animate.