### PR TITLE
Add heart rate recorder to consolidated data

### DIFF
--- a/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.h
+++ b/ResearchKit/ActiveTasks/ORKHealthQuantityTypeRecorder.h
@@ -30,7 +30,7 @@
 
 
 @import UIKit;
-#import <ResearchKit/ORKRecorder.h>
+#import <ResearchKit/ORKRecorder_Private.h>
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  an active task.
  */
 ORK_CLASS_AVAILABLE
-@interface ORKHealthQuantityTypeRecorder : ORKRecorder
+@interface ORKHealthQuantityTypeRecorder : ORKDataLogRecorder
 
 @property (nonatomic, copy, readonly) HKQuantityType *quantityType;
 


### PR DESCRIPTION
This is used when there is a watch to show the heart rate in the same file as location and core motion data. Pedometer is still a separate file b/c there isn't a simple means of consolidating the data from that source.