### PR TITLE
Remove references to macros that were deleted from iOS 11

### DIFF
--- a/ResearchKit/ActiveTasks/ORKWorkoutMessage.h
+++ b/ResearchKit/ActiveTasks/ORKWorkoutMessage.h
@@ -177,7 +177,6 @@ ORK_CLASS_AVAILABLE
  event happens.
  */
 ORK_CLASS_AVAILABLE
-HK_CLASS_AVAILABLE_IOS_WATCHOS(10_0, 3_0)
 @interface ORKEventWorkoutMessage : ORKWorkoutMessage
 
 /**

--- a/ResearchKit/ActiveTasks/ORKWorkoutStep.h
+++ b/ResearchKit/ActiveTasks/ORKWorkoutStep.h
@@ -111,7 +111,6 @@ typedef NS_ENUM(NSInteger, ORKLocationState) {
  active steps to measure the user's heart rate before and after the workout.
  */
 ORK_CLASS_AVAILABLE
-HK_CLASS_AVAILABLE_IOS_WATCHOS(10_0, 3_0)
 @interface ORKWorkoutStep : ORKPageStep
 
 /**

--- a/ResearchKit/ActiveTasks/ORKWorkoutStepViewController.h
+++ b/ResearchKit/ActiveTasks/ORKWorkoutStepViewController.h
@@ -40,7 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
  heart rate capture step.
  */
 ORK_CLASS_AVAILABLE
-HK_CLASS_AVAILABLE_IOS_WATCHOS(10_0, 3_0)
 @interface ORKWorkoutStepViewController : ORKPageStepViewController <WCSessionDelegate>
 
 @end

--- a/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.h
+++ b/ResearchKit/Common/ORKOrderedTask+ORKPredefinedActiveTask.h
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
                                          walkDuration:(NSTimeInterval)walkDuration
                                          restDuration:(NSTimeInterval)restDuration
                                  relativeDistanceOnly:(BOOL)relativeDistanceOnly
-                                              options:(ORKPredefinedTaskOption)options HK_AVAILABLE_IOS_ONLY(10_0);
+                                              options:(ORKPredefinedTaskOption)options API_AVAILABLE(ios(10.0)) API_UNAVAILABLE(watchos);
 
 
 /**


### PR DESCRIPTION
This allows the project to build in Xcode 9.