### PR TITLE
Fix negative reaction time assert firing when test failed

### DIFF
--- a/ResearchKit/ActiveTasks/ORKGoNoGoViewController.m
+++ b/ResearchKit/ActiveTasks/ORKGoNoGoViewController.m
@@ -316,7 +316,7 @@ static const NSTimeInterval OutcomeAnimationDuration = 0.3;
     gonogoResult.timestamp = _stimulusTimestamp;
     gonogoResult.samples = [samples copy];
     gonogoResult.timeToThreshold = go ? _thresholdTimestamp - _stimulusTimestamp : 0;
-    if (go) {
+    if (go && !incorrect) {
         NSAssert(_thresholdTimestamp - _stimulusTimestamp > 0, @"GoNoGo test had negative reaction time");
     }
     gonogoResult.go = go;


### PR DESCRIPTION
Fixed negative reaction time assert from firing for failed go tests